### PR TITLE
Add .prettierignore file for better formatting boundaries

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,43 @@
+# Build output
+dist/
+lib/
+build/
+
+# Dependencies
+node_modules/
+
+# Coverage reports
+coverage/
+.nyc_output/
+
+# Logs
+*.log
+logs/
+
+# Cache directories
+.cache/
+.parcel-cache/
+.eslintcache
+
+# Temporary files
+tmp/
+temp/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+
+# Package files
+*.tgz
+package-lock.json
+yarn.lock
+
+# Generated files
+*.tsbuildinfo
+
+# Documentation that should maintain original formatting
+CHANGELOG.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -39,5 +39,15 @@ yarn.lock
 # Generated files
 *.tsbuildinfo
 
+# Environment files
+.env
+.env.*
+
+# Test artifacts
+junit.xml
+
+# TypeScript
+*.d.ts.map
+
 # Documentation that should maintain original formatting
 CHANGELOG.md


### PR DESCRIPTION
This PR adds a missing .prettierignore file to complete the project's formatting setup.

## Changes
- Added .prettierignore to exclude build artifacts, dependencies, and generated files
- Prevents Prettier from formatting files that shouldn't be formatted
- Maintains proper formatting boundaries in the project

Closes #2

Generated with [Claude Code](https://claude.ai/code)